### PR TITLE
Add cmake install targets

### DIFF
--- a/CMake/bncsutilConfig.cmake.in
+++ b/CMake/bncsutilConfig.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/bncsutilTargets.cmake")
+
+set(bncsutil_FOUND TRUE)
+set(bncsutil_VERSION "@PROJECT_VERSION@")
+message(STATUS "Found bncsutil: ${bncsutil_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.25)
-project(bncsutil)
+SET(VERSION_MAJOR "1")
+SET(VERSION_MINOR "4")
+SET(VERSION_PATCH "3")
+
+project(bncsutil VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 
 set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR} "${PROJECT_SOURCE_DIR}/CMake/Modules")
 message(${CMAKE_BINARY_DIR})
-
-SET(VERSION_MAJOR "1")
-SET(VERSION_MINOR "4")
-SET(VERSION_PATCH "2")
 
 add_library(bncsutil SHARED)
 
@@ -97,8 +97,41 @@ if (MSVC)
 	set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT "bncsutil")
 endif()
 
-install(TARGETS bncsutil RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
+include(CMakePackageConfigHelpers)
+
+install(TARGETS bncsutil
+        EXPORT bncsutilTargets
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        INCLUDES DESTINATION include
+)
+
 install(FILES ${HEADERS} DESTINATION include/bncsutil)
+
+install(EXPORT bncsutilTargets
+        FILE bncsutilTargets.cmake
+        NAMESPACE bncsutil::
+        DESTINATION lib/cmake/bncsutil
+)
+
+configure_package_config_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/CMake/bncsutilConfig.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/bncsutilConfig.cmake"
+        INSTALL_DESTINATION lib/cmake/bncsutil
+)
+
+write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/bncsutilConfigVersion.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY AnyNewerVersion
+)
+
+install(FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/bncsutilConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/bncsutilConfigVersion.cmake"
+        DESTINATION lib/cmake/bncsutil
+)
 
 #CPack configuration
 SET(CPACK_GENERATOR "DEB" "RPM")
@@ -124,7 +157,7 @@ SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libgmp10")
 
 #RPM configuration
 SET(CPACK_RPM_PACKAGE_RELEASE 1)
-SET(CPACK_RPM_PACKAGE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/COPYING")
+SET(CPACK_RPM_PACKAGE_LICENSE "LGPL-2.1")
 SET(CPACK_RPM_PACKAGE_GROUP "bncsutil")
 SET(CPACK_RPM_PACKAGE_URL "https://github.com/BNETDocs/bncsutil")
 SET(CPACK_RPM_PACKAGE_REQUIRES "gmp")

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ been maintained over the course of several years by the open source Battle.net c
 # Usage
 `#include <bncsutil/bncsutil.h>` and link against `bncsutil.lib` or `libbncsutil.so`.
 
+For CMake add:
+```
+find_package(bncsutil REQUIRED)
+target_link_libraries(mytarget PRIVATE bncsutil::bncsutil)
+```
+
 # Building
 
 To force a specific build (32bit or 64bit) add `-DCMAKE_GENERATOR_PLATFORM=x86` or `-DCMAKE_GENERATOR_PLATFORM=x64` to CMake flags.


### PR DESCRIPTION
- add cmake targets to install so it is easy to include bncsutil to other CMake projects
- document find_package usage
- fix RPM license field

Please tag 1.4.3 after merge so I can use a tagged release in some downstream projects.